### PR TITLE
Fixes #252 gitTagElement can be specified

### DIFF
--- a/TreyDev.project
+++ b/TreyDev.project
@@ -4,5 +4,5 @@
   <project name="DevMacros.project"/>
   <token name="Lib-DNDB-TestLibrary"/>
   <token name="Lib-JSON-Editor"/>
-  <token name="Lib-Log4MT"/>
+  <token name="Lib-Log4MT" gitTagElement="label"/>
 </project>

--- a/doc/Config.md
+++ b/doc/Config.md
@@ -1,0 +1,28 @@
+# Config
+
+Developer tools use a config.ini in the root of the project (alongside the makefile) to control a few aspects of the tools.
+
+```
+[assemble]
+directory = output
+LibTokenGitTagElement = label
+
+[extract]
+directory = .
+```
+
+## Sections
+
+`[assemble]` applies to the `assemble` tool which pulls filesystem objects into MapTool assets.
+
+`[extract]` applies to the `extract` tool which pulls apart MapTool assets into filesystem objects (suitable for github).
+
+## Assemble Configuration
+
+`directory` is a directory in which to place assets created.  Many devs use `output` which creates an `output/` directory at the top of the project where all the assets will be built.  Note that absolute paths and Windows paths will not work if the assemble is run in the docker images.
+
+`LibTokenGitTagElement` is a top-level element into which the Git Tag will be placed (replacing or overwriting the element) on a token which has a name starting with 'Lib:'.  
+
+## Extract Configuration
+
+`directory` is a directory in which to place assets extracted.  The default is '.'.

--- a/doc/Project.md
+++ b/doc/Project.md
@@ -54,6 +54,12 @@ A token element must be empty and must contain a name attribute.
 
 A token name should refer to a token directory containing a content.xml, or a path to the content.xml.
 
+A token MAY have a gitTagElement attribute.  If a Token name begins with
+Lib: the current git tag string will be inserted when we build it.   By
+default the git tag string will be put into the gmName element.  You can
+use this attribute to put it onto a different element.  NB: This
+overwrites the named element.
+
 ## project
 ```
 <project name="Echo"/>

--- a/docker/MTAssetLibrary/AssetClasses.py
+++ b/docker/MTAssetLibrary/AssetClasses.py
@@ -611,7 +611,7 @@ class MTMacroObj(MTAsset):
         if type(new) == MTMacroObj:
             self.root.append(new.root)
 
-    def extract(self, save_name=None, output_dir=None, dryrun=None, verbose=None):
+    def extract(self, save_name=None, output_dir=None, dryrun=None):
         """
         MTMacroObj.extract() method
 
@@ -622,7 +622,6 @@ class MTMacroObj(MTAsset):
         Keyword Arguments
         save_name (default object_name) - temporary change of name to the object (and resulting files)
         dryrun (default None) - don't actually save anything
-        verbose (default None) - print out debugging information normally logged
         """
         # Properties, Campaigns uses this
         output_path = output_dir or 'macro'

--- a/docker/MTAssetLibrary/utils.py
+++ b/docker/MTAssetLibrary/utils.py
@@ -11,6 +11,7 @@ import datetime
 import random
 import string
 import logging as log
+import configparser
 from subprocess import Popen, run, PIPE
 from urllib.parse import quote_plus
 from lxml import objectify, etree
@@ -370,3 +371,24 @@ def run_extract(context, *args):
     p = Popen([context.extract, *args],
               stderr=PIPE, stdout=PIPE, close_fds=True)
     context.stdout, context.stderr = p.communicate()
+
+
+def LoadConfig():
+    c = configparser.ConfigParser()
+    c.read_dict(
+        {
+            'assemble': {
+                'directory': '.',
+                'LibTokenGitTagElement': 'label'
+            },
+            'extract': {
+                'directory': '.'
+            }
+        }
+    )
+    c.read(os.getenv('MTASSET_CONFIG') or 'config.ini')
+    if 'assemble' not in c:
+        c['assemble'] = {}
+    if 'directory' not in c['assemble']:
+        c['assemble']['directory'] = '.'
+    return c

--- a/docker/MTAssetLibrary/utils.py
+++ b/docker/MTAssetLibrary/utils.py
@@ -87,14 +87,21 @@ def GitShow():
         'tag': GitTag(),
         'branch': GitBranch(),
         'sha': GitSha(),
-        'dirty': GitDirty()
+        'dirty': GitDirty(),
+        'tagref': GitTagRef()
     }
 
 
 def GitTag():
-    """Returns git describe --tags --dirty """
+    """Returns git describe --tags --dirty --abbrev=8 """
     cmd = b'git describe --tags --dirty --abbrev=8'
     return GitCmd(cmd)
+
+
+def GitTagRef():
+    '''Returns GitTag after \d-g'''  # noqa: W605
+    tag = GitTag()
+    return re.sub(r'.*\d-g', '', tag)
 
 
 def GitDirty():
@@ -117,7 +124,7 @@ def GitSha():
     return GitCmd(cmd) or 'unknown'
 
 
-git_tag_str = GitSha() + GitDirty()
+git_tag_str = GitTagRef()
 git_comment_str = f'<!-- {github_url} {git_tag_str} -->'
 
 

--- a/docker/MTAssetLibrary/utils.py
+++ b/docker/MTAssetLibrary/utils.py
@@ -282,7 +282,7 @@ def write_macro_files(macro, tofilebase):
         command = macro.command.text or ''
         del(macro.command)
     log.info(f'extracting {macro.label} to {tofilebase}.xml')
-    pattern = f'(<!-- {github_url} [0-9a-z-]+ -->\n?)'
+    pattern = f'(<!-- {github_url} [0-9a-zA-Z-]+ -->\n?)'
     if match := re.match(pattern, command):
         command = command.replace(match[0], '')
     with open(tofilebase + '.xml', 'w') as fh:

--- a/docker/MTAssetLibrary/utils.py
+++ b/docker/MTAssetLibrary/utils.py
@@ -99,9 +99,9 @@ def GitTag():
 
 
 def GitTagRef():
-    '''Returns GitTag after \d-g'''  # noqa: W605
+    """Returns GitTag after \d-g"""
     tag = GitTag()
-    return re.sub(r'.*\d-g', '', tag)
+    return re.sub('.*\d-g', '', str(tag))
 
 
 def GitDirty():

--- a/docker/assemble
+++ b/docker/assemble
@@ -10,7 +10,7 @@ import os
 import sys
 sys.path.insert(0, 'docker')
 from argparse import ArgumentParser
-from MTAssetLibrary import GetAsset, tagset
+from MTAssetLibrary import GetAsset, tagset, LoadConfig
 import logging as log
 import configparser
 
@@ -21,12 +21,7 @@ def ConfigArgs():
     Returns: argumentparser namespace with config and commandline arguments
     """
 
-    c = configparser.ConfigParser()
-    c.read(os.getenv('MTASSET_CONFIG') or 'config.ini')
-    if 'assemble' not in c:
-        c['assemble'] = {}
-    if 'directory' not in c['assemble']:
-        c['assemble']['directory'] = '.'
+    c = LoadConfig()
 
     AP = ArgumentParser(description = "MapTool Asset Assembler")
 
@@ -57,9 +52,10 @@ def ConfigArgs():
 
     AP.add_argument(
             '--gitTagElement',
+            default=c['assemble'].get('LibTokenGitTagElement', 'gmName'),
             help='Element to put a git tag string on a token with Lib: name, default None')
 
-    return AP.parse_args()
+    return c, AP.parse_args()
 
 def SetupLogging(av):
     """SetupLogging
@@ -82,7 +78,7 @@ def SetupLogging(av):
 
 if __name__ == '__main__':
 
-    av = ConfigArgs()
+    config, av = ConfigArgs()
     SetupLogging(av)
 
     asset = GetAsset(*av.input, name=av.list, path=av.output)

--- a/docker/assemble
+++ b/docker/assemble
@@ -10,7 +10,7 @@ import os
 import sys
 sys.path.insert(0, 'docker')
 from argparse import ArgumentParser
-from MTAssetLibrary import GetAsset
+from MTAssetLibrary import GetAsset, tagset
 import logging as log
 import configparser
 
@@ -55,6 +55,10 @@ def ConfigArgs():
             action='store_true',
             help='Turn on informative output')
 
+    AP.add_argument(
+            '--gitTagElement',
+            help='Element to put a git tag string on a token with Lib: name, default None')
+
     return AP.parse_args()
 
 def SetupLogging(av):
@@ -82,4 +86,6 @@ if __name__ == '__main__':
     SetupLogging(av)
 
     asset = GetAsset(*av.input, name=av.list, path=av.output)
+    if av.gitTagElement and asset.tag == tagset.token.tag:
+        asset.gitTagElement = av.gitTagElement
     asset.assemble()

--- a/docker/extract
+++ b/docker/extract
@@ -12,7 +12,7 @@ import os
 import sys
 sys.path.insert(0, 'docker')
 from argparse import ArgumentParser
-from MTAssetLibrary import GetAsset
+from MTAssetLibrary import GetAsset, LoadConfig
 import logging as log
 import configparser
 
@@ -23,12 +23,7 @@ def ConfigArgs():
     Returns: argumentparser namespace with config and commandline arguments
     """
 
-    c = configparser.ConfigParser()
-    c.read(os.getenv('MTASSET_CONFIG') or 'config.ini')
-    if 'extract' not in c:
-        c['extract'] = {}
-    if 'extractdirectory' not in c['extract']:
-        c['extract']['directory'] = '.'
+    c = LoadConfig()
 
     AP = ArgumentParser(description = "MapTool Asset Extractor")
 
@@ -58,7 +53,7 @@ def ConfigArgs():
             action='store_true',
             help='Turn on informative output')
 
-    return AP.parse_args()
+    return c, AP.parse_args()
 
 def SetupLogging(av):
     """SetupLogging
@@ -81,7 +76,7 @@ def SetupLogging(av):
 
 if __name__ == '__main__':
 
-    av = ConfigArgs()
+    config, av = ConfigArgs()
     SetupLogging(av)
 
     asset = GetAsset(*av.input, name=av.name, path=av.output)

--- a/makefile
+++ b/makefile
@@ -6,14 +6,21 @@ else
 	DOTSLASH := ./
 endif
 
+PROJECTS := $(wildcard *.project)
+
 project: DNDBeyond.project $(shell echo Lib-DNDBeyond/*)
 	$(DOTSLASH)dockerrun assemble DNDBeyond.project
 
-all:
+%.project:
+	$(DOTSLASH)dockerrun assemble $<
+
+all: Lib-Log4MT
 	$(DOTSLASH)dockerrun assemble Ashes+PF2.project
 	$(DOTSLASH)dockerrun assemble DNDBeyond.project
 	$(DOTSLASH)dockerrun assemble DNDBeyond+Open5e.project
 	$(DOTSLASH)dockerrun assemble Open5e.project
+
+Lib-Log4MT:
 	$(DOTSLASH)dockerrun assemble Lib-Log4MT
 
 project-local: DNDBeyond.project $(shell echo LIB-DNDBeyond/*)
@@ -55,7 +62,6 @@ behave: behave.image clean
 	behave --no-capture --no-capture-stderr --no-logcapture
 	git status --ignored
 
-.PHONY: build clean test log behave ptw unzip flake8 tester
 
 log:
 	rm -f output/Lib%3ALog4MT.rptok
@@ -89,3 +95,5 @@ vscode: .vscode/extensions.json maptool-macros.code-workspace
 
 flake8:
 	flake8 --ignore E501,E402,F405
+
+.PHONY: build clean test log behave ptw unzip flake8 tester Lib-Log4MT $(PROJECTS)

--- a/test/features/assemble.feature
+++ b/test/features/assemble.feature
@@ -117,7 +117,6 @@ Feature: Assemble
          And that macroset contains macros from the "second" project
          And that macroset contains macros from the "third" project
 
-    @wip
     Scenario: assemble a token pulls in propertyMapCI.xml automatically
        Given I have a token extract directory
          And the content.xml does not have a propertyMapCI

--- a/test/features/assemble.feature
+++ b/test/features/assemble.feature
@@ -123,3 +123,12 @@ Feature: Assemble
          And that directory has a propertyMapCI.xml file
         When I assemble that token
         Then the asset has a propertyMapCI
+
+    @wip
+    Scenario: assemble a token puts git tag on element in config file
+       Given I have a token extract directory
+         And that token name begins with Lib
+         And LibTokenGitTagElement in config.ini
+        When I assemble that token
+        Then the asset has the element named
+         And the element has the git tag string

--- a/test/features/extract.feature
+++ b/test/features/extract.feature
@@ -56,7 +56,6 @@ Feature: extract
          And I should get a macro command file
          And that macro command file should not have a github comment
 
-    @wip
     Scenario: Extract a macro from token with github comment
        Given I have a token with github comment on a macro
         When I extract a token

--- a/test/features/extract.feature
+++ b/test/features/extract.feature
@@ -46,7 +46,8 @@ Feature: extract
         Then I should get a properties directory
          And I should get a properties/content.xml
          And I should get a properties/properties.xml
-        
+
+    @wip
     Scenario: Extract a macro with github comment
        Given I have a macro asset with github comment
         When I extract a macro
@@ -55,6 +56,7 @@ Feature: extract
          And I should get a macro command file
          And that macro command file should not have a github comment
 
+    @wip
     Scenario: Extract a macro from token with github comment
        Given I have a token with github comment on a macro
         When I extract a token

--- a/test/features/steps/extract.py
+++ b/test/features/steps/extract.py
@@ -233,8 +233,7 @@ def step_impl(context):   # noqa: F811
 def step_impl(context):   # noqa: F811
     fn = context.macrofilename
     assert os.path.exists(fn), f"{fn} not in tmpdir = '{os.getcwd()}'"
-    assert False, f"{fn} contains {github_url} but should not tmpdir = '{os.getcwd()}'\n\n{open(fn).read()}"
-    assert github_url not in open(fn).read(), f"{fn} contains {github_url} but should not"
+    assert github_url not in open(fn).read(), f"{fn} contains {github_url} but should not, tmpdir = '{os.getcwd()}'"
 
 
 @given(u'I have a token with github comment on a macro')

--- a/test/features/steps/extract.py
+++ b/test/features/steps/extract.py
@@ -26,8 +26,8 @@ def step_impl(context):  # noqa: F811
     context.macrosrc = context.source['macro'][0]['path']
     assert os.path.exists(context.macrosrc)
     run_assemble(context, context.macrosrc)
-    context.macrofile = context.source['macro'][0]['filename'] + '.' + tagset.macro.ext
-    assert os.path.exists(context.macrofile)
+    context.macrofile = os.path.join('output',context.source['macro'][0]['filename']) + '.' + tagset.macro.ext
+    assert os.path.exists(context.macrofile), f"no {context.macrofile} in '{os.getcwd()}'"
 
 
 @given(u'I have a sample macroset')
@@ -43,7 +43,7 @@ def step_impl(context):   # noqa: F811
         context.source['macro'][1]['path']
     )
     context.macrosetfilename = context.macrosetname + '.' + tagset.macroset.ext
-    assert os.path.exists(context.macrosetfilename)
+    assert os.path.exists(os.path.join('output', context.macrosetfilename)), f"no {context.macrosetfilename} in '{os.getcwd()}'"
 
 
 @given(u'I have a sample properties')
@@ -149,9 +149,9 @@ def step_impl(context):   # noqa: F811
 
 @when(u'I extract a macro')
 def step_impl(context):   # noqa: F811
-    assert os.path.exists(context.macrofile)
+    assert os.path.exists(context.macrofile), f"no {context.macrofile} in '{os.getcwd()}'"
     run_extract(context, context.macrofile)
-    assert b'Error' not in context.stderr
+    assert b'Error' not in context.stderr, f"{context.stderr} running extract on {context.macrofile} in '{os.getcwd()}'"
 
 
 @then(u'I should get a macro directory')
@@ -173,8 +173,8 @@ def step_impl(context):   # noqa: F811
 
 @when(u'I extract a macroset')
 def step_impl(context):   # noqa: F811
-    assert os.path.exists(context.macrosetfilename)
-    run_extract(context, context.macrosetfilename)
+    assert os.path.exists(os.path.join('output', context.macrosetfilename)), f"{context.macrosetfilename} not found in '{os.getcwd()}'"
+    run_extract(context, os.path.join('output', context.macrosetfilename))
     assert b'Error' not in context.stderr, f"{context.stderr}\ntmpdir = '{os.getcwd()}'"
 
 
@@ -225,8 +225,7 @@ def step_impl(context):   # noqa: F811
     m.root.command = objectify.StringElement(git_comment_str + '\n' + m.root.command.text)
     context.macroname = random_string()
     m.assemble(context.macroname)
-    context.macrofile = context.macroname + '.' + tagset.macro.ext
-    assert os.path.exists(context.macrofile)
+    assert os.path.exists(context.macrofile), f"{context.macrofile} not found in '{os.getcwd()}'"
 
 
 @then(u'that macro command file should not have a github comment')

--- a/test/features/steps/extract.py
+++ b/test/features/steps/extract.py
@@ -233,7 +233,8 @@ def step_impl(context):   # noqa: F811
 def step_impl(context):   # noqa: F811
     fn = context.macrofilename
     assert os.path.exists(fn), f"{fn} not in tmpdir = '{os.getcwd()}'"
-    assert github_url not in open(fn).read()
+    assert False, f"{fn} contains {github_url} but should not tmpdir = '{os.getcwd()}'\n\n{open(fn).read()}"
+    assert github_url not in open(fn).read(), f"{fn} contains {github_url} but should not"
 
 
 @given(u'I have a token with github comment on a macro')


### PR DESCRIPTION
The Token assemble now takes the element name to
overwrite as an argument.  The git tag string also has
also been updated as in #183.

This change can be effected in two ways:

assemble TokenDir --gitTagElement <name>

<project>
  <token name="TokenDir" gitTagElement="name"/>
</project>